### PR TITLE
Adjusting CSS to Account for Header

### DIFF
--- a/css/header.css
+++ b/css/header.css
@@ -1,7 +1,7 @@
 
 /*First Section - Always True*/
 header {
-    height: 30px;
+    height: var(--header-height);
     width: 100%;
     position: fixed;
     display: grid;

--- a/css/income.css
+++ b/css/income.css
@@ -1,8 +1,23 @@
+body {
+    display: grid;
+    /*Needed because fixed position of header is taken out of doc flow consideration*/
+    margin-top: var(--header-height);
+}
+
+header {
+    border: 1px solid blue;
+}
+
+main {
+    border: 1px solid red;
+}
+
 #summaryCards {
     display: flex;
     flex-direction: row;
     padding: 0px 20px;
     justify-content: space-around;
+    margin: 5px;
 }
 
 #summaryCards > div {
@@ -63,5 +78,4 @@ th, td {
 .altRow {
     background-color: lightslategray;
 }
-
 

--- a/css/variables.css
+++ b/css/variables.css
@@ -6,4 +6,6 @@
     --contrast-color: #F6BC79;
     --alternate-color: #78A57B;
     --main-font-color: #000000;
+
+    --header-height: 30px;
   }

--- a/income.html
+++ b/income.html
@@ -40,4 +40,5 @@
 </body>
 <script src="https://d3js.org/d3.v7.min.js"></script>
 <script src="js\income.js"></script>
+<script src="js\header.js"></script>
 </html>


### PR DESCRIPTION
Learned that when an item is in a `fixed` or `absolute` position via CSS, then it is no longer considered part of the document flow. For this reason, I put the approriate margin in place on the body for the income page. Will need to do the same for other existing, and any future pages.