### PR TITLE
Adding Income Related Objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import {accountMap, currentAccountMap, clearAccountMap, clearCurrentAccountMap, fetchAccountData, fetchCurrentAccountData, loadAccountData, loadCurrentAccountData, retrieveAccountData, retrieveCurrentAccountData} from './js/main.js';
+import {accountMap, currentAccountMap, incomeMap, clearAccountMap, clearCurrentAccountMap, fetchAccountData, fetchCurrentAccountData, fetchIncomeData, loadAccountData, loadCurrentAccountData, retrieveAccountData, retrieveCurrentAccountData} from './js/main.js';
 
 /*Will be replacing these with a class.*/
 const currencyFormatCents = new Intl.NumberFormat('en-US', {
@@ -35,7 +35,8 @@ function formatDateToMMDDYYYY(date) {
 
 async function main() {
     localStorage.removeItem('accountData');
-    localStorage.removeItem('currentAccountData')
+    localStorage.removeItem('currentAccountData');
+    localStorage.removeItem('incomeData');
     clearAccountMap();
     clearCurrentAccountMap();
     retrieveAccountData();
@@ -55,6 +56,13 @@ async function main() {
     }
     //console.log(currentAccountMap);
 
+    //avoid an api call / loading data if data already exists
+    if (Object.keys(incomeMap.getAllByTicker()).length === 0) {
+        const incomeData = await fetchIncomeData();
+        // Have the data coming back in a single output
+        // Next step is to load the data just like Accounts were
+        console.log(incomeData);
+    }
 
     updateStarterPortVal()
     updateChartPortVal()

--- a/js/income.js
+++ b/js/income.js
@@ -1,0 +1,35 @@
+import Ticker from './ticker.js';
+import Account from './account.js';
+
+class Income {
+    static validStatuses = ['Received', 'Announced', 'Estimated']
+
+    constructor(ticker, account, payDate, institutionName, incomeAmount, incomeStatus, incomeRecent) {
+        if(!(ticker instanceof Ticker)) {
+            throw new TypeError('ticker must be an instance of Ticker');
+        }
+        if(!(account instanceof Account)) {
+            throw new TypeError('account must be an instance of Account');
+        }
+
+        this.ticker = ticker;
+        this.account = account;
+        this.payDate = new Date(payDate);
+        this.institutionName = institutionName;
+        this.incomeAmount = incomeAmount;
+
+        // Validation for incomeStatus attribute
+        if (!Income.validStatuses.includes(incomeStatus)) {
+            throw new TypeError(`incomeStatus must be one of ${Income.validStatuses.join(", ")}`);
+        }
+        this.incomeStatus = incomeStatus;
+
+        // Validation for boolean attribute
+        if (typeof incomeRecent !== 'boolean') {
+            throw new TypeError('incomeRecent must be a boolean');
+        }
+        this.incomeRecent = incomeRecent;
+    }
+}
+
+export default Income;

--- a/js/incomeMap.js
+++ b/js/incomeMap.js
@@ -1,0 +1,65 @@
+import Ticker from './ticker.js';
+import Income from "./income.js";
+import { accountMap } from './main.js';
+
+class IncomeMap {
+    constructor() {
+        this.byTicker = new Map();
+        this.byDate = new Map();
+        this.byAccount = new Map();
+    }
+
+    addIncome(income) {
+        if (!(income instanceof Income)) {
+            throw new TypeError('income must be an instance of Income');
+        }
+
+        // Add by Ticker
+        if (!this.byTicker.has(income.ticker.tickerSymbol)) {
+            this.byTicker.set(income.ticker.tickerSymbol, []);
+        }
+        this.byTicker.get(income.ticker.tickerSymbol).push(income);
+
+        // Add by Date
+        const dateKey = income.payDate.toISOString().split('T')[0];
+        if (!this.byDate.has(dateKey)) {
+            this.byDate.set(dateKey, []);
+        }
+        this.byDate.get(dateKey).push(income);
+
+        const accountKey = income.account.accountName;
+        if (!this.byAccount.has(accountKey)) {
+            this.byAccount.set(accountKey, [])
+        }
+        this.byAccount.get(accountKey).push(income);
+    }
+
+    getByTicker(tickerSymbol) {
+        return this.byTicker.get(tickerSymbol) || [];
+    }
+
+    getByDate(date) {
+        return this.byDate.get(date) || [];
+    }
+
+    getByAccount(accountName) {
+        return this.byAccount.get(accountName) || [];
+    }
+
+    getAllByTicker() {
+        return Array.from(this.byTicker.entries()).reduce((acc, [ticker, incomes]) => {
+            acc[ticker] = incomes;
+            return acc;
+        }, {});
+    }
+
+    getAllByAccount() {
+        return Array.from(this.byAccount.entries()).reduce((acc, [account, incomes]) => {
+            acc[account] = incomes;
+            return acc;
+        }, {});
+    }
+
+}
+
+export default IncomeMap;

--- a/js/ticker.js
+++ b/js/ticker.js
@@ -1,0 +1,8 @@
+class Ticker {
+    constructor(tickerSymbol, tickerName) {
+        this.tickerSymbol = tickerSymbol;
+        this.tickerName = tickerName;
+    }
+}
+
+export default Ticker;


### PR DESCRIPTION
Adding a number of supporting JS files to help define the `Income` and `IncomeMap` objects. Starting down the road of retrieving  / loading / storing the Income related data just the same as the `Account` data. This will make the process of loading the relevant data a lot easier.