### PR TITLE
Made Stacked Line Chart Colors Solid

### DIFF
--- a/historical.js
+++ b/historical.js
@@ -257,13 +257,19 @@ async function updateChartPortStackVal() {
                     }
                 }
             },
-            legendCallback: function(chart) {
-                console.log(`Testing what this is, ${chart}`);
-            },
         }
 
 
     })
+
+    function setAlphaForDatasets(datasets, alpha) {
+        datasets.forEach(function(dataset) {
+            dataset.backgroundColor = dataset.backgroundColor.replace(/rgba\((\d+), (\d+), (\d+), [^)]+\)/, `rgba($1, $2, $3, ${alpha})`);
+            dataset.borderColor = dataset.borderColor.replace(/rgba\((\d+), (\d+), (\d+), [^)]+\)/, `rgba($1, $2, $3, ${alpha})`);
+        })
+    }
+
+    setAlphaForDatasets(myChart.data.datasets, 1);
 
     function drawCustomLegend(chart, legend) {
         console.log(`I'm Running! ${chart}`);


### PR DESCRIPTION
Made it clearer for each of the colors in the stacked line chart to differentaite between series by making the stacked lines solid filling. This avoids overlap of translucent colors mixing.